### PR TITLE
Use provider interfaces in app globals

### DIFF
--- a/internal/app/vars.go
+++ b/internal/app/vars.go
@@ -1,6 +1,11 @@
 package app
 
 import (
+	"github.com/morph/internal/aiservice"
+	"github.com/morph/internal/botservice"
+	"github.com/morph/internal/deeplinkgenerator"
+	"github.com/morph/internal/shorturl"
+	"github.com/morph/internal/taskservice"
 	"github.com/morph/third_party/googletasks"
 	"github.com/morph/third_party/moneywiz"
 	"github.com/morph/third_party/openai"
@@ -8,8 +13,8 @@ import (
 	"github.com/morph/third_party/telegram"
 )
 
-var bot telegram.Telegram
-var aiService openai.OpenAI
-var shortURLService shortio.ShortIO
-var deepLinkGenerator moneywiz.DeepLinkGenerator
-var taskService googletasks.GoogleTasks
+var bot botservice.BotService = telegram.Telegram{}
+var aiService aiservice.AIService = openai.OpenAI{}
+var shortURLService shorturl.ShortURL = shortio.ShortIO{}
+var deepLinkGenerator deeplinkgenerator.DeepLinkGenerator = moneywiz.DeepLinkGenerator{}
+var taskService taskservice.TaskService = googletasks.GoogleTasks{}

--- a/internal/botservice/botservice.go
+++ b/internal/botservice/botservice.go
@@ -1,6 +1,6 @@
 package botservice
 
-import "net/http"
+import "io"
 
 type BotMessage struct {
 	MessageID int64
@@ -11,6 +11,6 @@ type BotMessage struct {
 
 type BotService interface {
 	GetChatID() (int64, error)
-	Parse(r *http.Request) *BotMessage
+	Parse(body io.ReadCloser) *BotMessage
 	SendMessage(chatID int64, text string, replyToMessageID *int64)
 }

--- a/internal/deeplinkgenerator/deeplinkgenerator.go
+++ b/internal/deeplinkgenerator/deeplinkgenerator.go
@@ -1,5 +1,7 @@
 package deeplinkgenerator
 
+import "time"
+
 type DeepLinkGenerator interface {
-	Create(category string, subcategory string, amount float64) string
+	Create(category string, subcategory string, account string, amount float64, date time.Time) string
 }

--- a/third_party/mono/mono.go
+++ b/third_party/mono/mono.go
@@ -75,6 +75,10 @@ func ParseWebhookRequest(r *http.Request) (*WebhookPayload, error) {
 	return &payload, nil
 }
 
+// Client-info types are used by the manual account discovery helper below.
+// They are intentionally kept even though the webhook flow only needs statement data:
+// GetClientInfo lets us fetch Mono account IDs and map them in the app handlers.
+
 // Account represents a client account
 type Account struct {
 	ID           string   `json:"id"`
@@ -111,9 +115,9 @@ type ManagedClientAccount struct {
 
 // ManagedClient represents a managed client (e.g., FOP account)
 type ManagedClient struct {
-	ClientID string               `json:"clientId"`
-	TIN      int64                `json:"tin"`
-	Name     string               `json:"name"`
+	ClientID string                 `json:"clientId"`
+	TIN      int64                  `json:"tin"`
+	Name     string                 `json:"name"`
 	Accounts []ManagedClientAccount `json:"accounts"`
 }
 
@@ -128,7 +132,7 @@ type ClientInfo struct {
 	ManagedClients []ManagedClient `json:"managedClients"`
 }
 
-// GetClientInfo retrieves client information including accounts from the Mono API
+// GetClientInfo retrieves Mono account metadata for operational account-ID discovery.
 func GetClientInfo() (*ClientInfo, error) {
 	apiKey := os.Getenv("MORPH_MONO_API_KEY")
 	if apiKey == "" {


### PR DESCRIPTION
## Summary
- Wire app-level service globals through provider interfaces instead of concrete implementations
- Update provider interface signatures to match Telegram and MoneyWiz implementations
- Document Mono client-info account discovery code so it is not mistaken for dead code

## Tests
- GOCACHE=/Users/max/Developer/morph/.cache/go-build go test ./...
- GOCACHE=/Users/max/Developer/morph/.cache/go-build go vet ./...