### PR TITLE
Add notification handler for bank push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The application consists of five main Google Cloud Functions that work together 
 - **Flow**:
   1. Receives the source app name, notification title, message and optional date
   2. Uses AI to classify the notification into a category, subcategory, and amount
-  3. Resolves the MoneyWiz account name from the source app (see `appAccountMap` in `internal/app/notifications.go`)
+  3. Resolves the MoneyWiz account name from the source app and the masked account number in the message — BBVA maps to a single account, while PUMB (`Рахунок: *0451`) and Privat24 (`5*85`) resolve per card (see `resolveAccountName` in `internal/app/notifications.go`). Unrecognized apps/accounts fall back to the app name.
   4. Generates a MoneyWiz deep link (with the provided date) and shortens it
   5. Schedules a Telegram message with the categorized transaction and deep link
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ export MORPH_CLOUD_FUNCTION_URL="https://YOUR_REGION-YOUR_PROJECT.cloudfunctions
 
 ## Architecture Overview
 
-The application consists of four main Google Cloud Functions that work together to process and manage financial transactions:
+The application consists of five main Google Cloud Functions that work together to process and manage financial transactions:
 
 ### 1. `cashHandler`
 - **Purpose**: Processes manual cash transactions entered by users via Telegram
@@ -168,6 +168,20 @@ The application consists of four main Google Cloud Functions that work together 
   1. Receives message details via HTTP request
   2. Sends the message to the specified chat ID
   3. Supports message replies through `ReplyToMessageID`
+
+### 5. `notificationHandler`
+- **Purpose**: Processes bank push notifications forwarded by an iOS Shortcut (iOS 27+ can parse incoming push notifications and call a service)
+- **Request body** (`application/json`):
+  ```json
+  { "app": "BBVA ES", "title": "Recibo cargado", "message": "Se ha cargado en tu cuenta *3297 un adeudo de ... de 79,81 EUR.", "date": "2026-06-26T13:13:00+03:00" }
+  ```
+  `date` is optional. It accepts an absolute instant (RFC3339/ISO 8601 with timezone, or a Unix epoch in seconds/milliseconds) or a naive datetime copied from the notification text (interpreted as Europe/Kyiv). When omitted or unrecognized, the current server time is used.
+- **Flow**:
+  1. Receives the source app name, notification title, message and optional date
+  2. Uses AI to classify the notification into a category, subcategory, and amount
+  3. Resolves the MoneyWiz account name from the source app (see `appAccountMap` in `internal/app/notifications.go`)
+  4. Generates a MoneyWiz deep link (with the provided date) and shortens it
+  5. Schedules a Telegram message with the categorized transaction and deep link
 
 ## Task Processing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ func main() {
 	http.HandleFunc("/monoHandler", app.MonoHandler)
 	http.HandleFunc("/monoWebHook", app.MonoWebHook)
 	http.HandleFunc("/sendMessage", app.SendMessage)
+	http.HandleFunc("/notificationHandler", app.NotificationHandler)
 
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
 		log.Fatalf("Error starting server: %s", err)

--- a/function.go
+++ b/function.go
@@ -12,6 +12,7 @@ func init() {
 	functions.HTTP("monoHandler", monoHandler)
 	functions.HTTP("monoWebHook", monoWebHook)
 	functions.HTTP("sendMessage", sendMessage)
+	functions.HTTP("notificationHandler", notificationHandler)
 }
 
 func cashHandler(w http.ResponseWriter, r *http.Request) {
@@ -28,4 +29,8 @@ func monoWebHook(w http.ResponseWriter, r *http.Request) {
 
 func sendMessage(w http.ResponseWriter, r *http.Request) {
 	app.SendMessage(w, r)
+}
+
+func notificationHandler(w http.ResponseWriter, r *http.Request) {
+	app.NotificationHandler(w, r)
 }

--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -1,0 +1,172 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/morph/internal/category"
+	"github.com/morph/internal/taskservice"
+)
+
+// notificationRequest is the payload forwarded by the iOS Shortcut that parses a
+// bank push notification into its source app name, title and body. Date is
+// optional and, when present, sets the transaction date on the deep link.
+type notificationRequest struct {
+	App     string `json:"app"`
+	Title   string `json:"title"`
+	Message string `json:"message"`
+	Date    string `json:"date"`
+}
+
+// parseNotificationDate interprets the optional date forwarded by the Shortcut.
+// It accepts an absolute instant (RFC3339 timestamp carrying its own offset, or a
+// Unix epoch in seconds or milliseconds) or a naive datetime copied from the
+// notification text. Naive values have no timezone, so they are read in the same
+// zone the MoneyWiz deep link renders in. It falls back to the current time when
+// the value is absent or unrecognized.
+func parseNotificationDate(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Now()
+	}
+
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t
+	}
+
+	if epoch, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		if epoch > 1e12 {
+			return time.Unix(epoch/1000, 0)
+		}
+		return time.Unix(epoch, 0)
+	}
+
+	loc, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		loc = time.FixedZone("EET", 2*60*60)
+	}
+	naiveLayouts := []string{
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"02-01-2006 15:04:05",
+		"02-01-2006 15:04",
+	}
+	for _, layout := range naiveLayouts {
+		if t, err := time.ParseInLocation(layout, raw, loc); err == nil {
+			return t
+		}
+	}
+
+	log.Printf("[Morph] Could not parse notification date %q, using current time", raw)
+	return time.Now()
+}
+
+// appAccountMap maps a notification source app to the MoneyWiz account name used
+// in deep links. The full app:account mapping will be provided later; until then
+// unknown apps fall back to the app name itself.
+var appAccountMap = map[string]string{}
+
+// getAccountNameFromApp resolves the MoneyWiz account name for a notification app.
+func getAccountNameFromApp(appName string) string {
+	if accountName, ok := appAccountMap[appName]; ok {
+		return accountName
+	}
+
+	log.Printf("[Morph] Unknown notification app: %q, using app name as account", appName)
+	return appName
+}
+
+// NotificationHandler turns a parsed bank push notification (app, title, message)
+// into a categorized MoneyWiz deep link and delivers it to Telegram.
+func NotificationHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println("[Morph] Started notification handling...")
+
+	var notification notificationRequest
+	if err := json.NewDecoder(r.Body).Decode(&notification); err != nil {
+		log.Printf("[Morph] Could not parse notification %s", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Could not parse notification"))
+		return
+	}
+
+	if notification.Title == "" && notification.Message == "" {
+		log.Printf("[Morph] No content in notification")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+		return
+	}
+
+	// The notification is forwarded by a Shortcut and carries no chat ID, so
+	// resolve the target chat from configuration.
+	chatID, err := bot.GetChatID()
+	if err != nil {
+		log.Printf("[Morph] Error getting chat ID: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Could not get chat ID"))
+		return
+	}
+
+	ctx := context.Background()
+	taskService.Connect(&ctx)
+	defer taskService.Close()
+
+	categories := category.GetCategoriesInJSON()
+	hints := category.GetHintsInJSON()
+
+	systemPrompt := "You are a data analyst. Your task is to classify a bank push notification into a category, subcategory, and amount. You MUST ONLY use the categories and subcategories provided below—do not invent new ones. If the input does not match any, use 'Other' for category and an empty string for subcategory. Extract the transaction amount from the notification text as a number. Output a single-line JSON object with only these fields: category, subcategory, amount. Example of the output: {\"category\": \"Children\", \"subcategory\": \"Vocal\", \"amount\": 400.0}. Categories and subcategories: " + categories + " Hints: " + hints + " IMPORTANT: Do not add any explanation or extra text. Only output the JSON object."
+	userPrompt := fmt.Sprintf("Classify this bank push notification.\nApp: %s\nTitle: %s\nMessage: %s", notification.App, notification.Title, notification.Message)
+
+	response := aiService.Request("Morph", "Translates a bank push notification into: Category, Subcategory, Amount", systemPrompt, userPrompt, &ctx)
+	if response == nil {
+		log.Printf("[Morph] No response from AI")
+		scheduledMessage := taskservice.ScheduledMessage{
+			ChatID:           chatID,
+			Text:             "No response from AI",
+			ReplyToMessageID: nil,
+		}
+		taskService.ScheduleMessage(&ctx, scheduledMessage, time.Now())
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+		return
+	}
+
+	absoluteAmount := math.Abs(response.Amount)
+	accountName := getAccountNameFromApp(notification.App)
+
+	txTime := parseNotificationDate(notification.Date)
+
+	log.Printf("[Morph] Response: %s %s %f (account: %s, date: %s)", response.Category, response.Subcategory, absoluteAmount, accountName, txTime)
+	text := fmt.Sprintf("📲 %s\nCategory: %s\nSubcategory: %s\nAmount: %.2f", notification.App, response.Category, response.Subcategory, absoluteAmount)
+
+	deepLink := deepLinkGenerator.Create(response.Category, response.Subcategory, accountName, absoluteAmount, txTime)
+
+	url, err := shortURLService.Shorten(deepLink)
+	if err != nil {
+		log.Printf("[Morph] Error shortening URL: %v", err)
+		text += "\nError shortening URL: " + err.Error()
+	} else {
+		log.Printf("[Morph] Shortened URL: %s", url)
+		text += "\n" + url
+	}
+
+	log.Printf("[Morph] Sending message to chat %d", chatID)
+
+	scheduledMessage := taskservice.ScheduledMessage{
+		ChatID:           chatID,
+		Text:             text,
+		ReplyToMessageID: nil,
+	}
+	taskService.ScheduleMessage(&ctx, scheduledMessage, time.Now())
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+	log.Println("[Morph] Notification handler finished")
+}

--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -69,19 +69,82 @@ func parseNotificationDate(raw string) time.Time {
 	return time.Now()
 }
 
-// appAccountMap maps a notification source app to the MoneyWiz account name used
-// in deep links. The full app:account mapping will be provided later; until then
-// unknown apps fall back to the app name itself.
-var appAccountMap = map[string]string{}
+// bbvaAccount is the single MoneyWiz account used for every BBVA notification,
+// regardless of the account number shown in the message.
+const bbvaAccount = "BBVAEur"
 
-// getAccountNameFromApp resolves the MoneyWiz account name for a notification app.
-func getAccountNameFromApp(appName string) string {
-	if accountName, ok := appAccountMap[appName]; ok {
-		return accountName
+// pumbAccounts maps the masked account number as it appears in a PUMB notification
+// (e.g. "Рахунок: *0451") to the MoneyWiz account name.
+var pumbAccounts = map[string]string{
+	"*0451": "PumbUAHPlatinum",
+	"*2164": "PumbUAHVirtual",
+	"*5381": "PumbUSD",
+	"*0404": "PumbEUR",
+}
+
+// privatAccounts maps the masked account token as it appears in a Privat24
+// notification (e.g. "5*85") to the MoneyWiz account name.
+var privatAccounts = map[string]string{
+	"5*85": "PrivatOnlineUAH",
+	"3*87": "PrivatOnlineUSD",
+	"2*62": "PrivatOnlineEUR",
+	"5*30": "StartupPrivatUAH",
+	"9*88": "StartupPrivatUSD",
+	"6*64": "PrivatEntrepreneurUAH",
+	"6*31": "PrivatPaymentsUAH",
+	"6*99": "PrivatUniversalUAH",
+	"0*07": "PrivatPaymentsUSD",
+	"1*89": "PrivatEUR",
+}
+
+// resolveAccountName determines the MoneyWiz account for a notification. The bank
+// is identified from the app name; PUMB and Privat24 then resolve the specific
+// account from the masked account number embedded in the message, while BBVA
+// always maps to a single account. Unrecognized apps/accounts fall back to the
+// app name so the transaction is still delivered (for manual account selection).
+func resolveAccountName(app string, message string) string {
+	switch detectBank(app) {
+	case "bbva":
+		return bbvaAccount
+	case "pumb":
+		if account := matchAccountToken(message, pumbAccounts); account != "" {
+			return account
+		}
+	case "privat":
+		if account := matchAccountToken(message, privatAccounts); account != "" {
+			return account
+		}
 	}
 
-	log.Printf("[Morph] Unknown notification app: %q, using app name as account", appName)
-	return appName
+	log.Printf("[Morph] Could not resolve account for app %q, using app name", app)
+	return app
+}
+
+// detectBank maps a notification source app name to a known bank identifier.
+func detectBank(app string) string {
+	normalized := strings.ToLower(strings.TrimSpace(app))
+	switch {
+	case strings.Contains(normalized, "bbva"):
+		return "bbva"
+	case strings.Contains(normalized, "pumb") || strings.Contains(normalized, "пумб"):
+		return "pumb"
+	case strings.Contains(normalized, "privat"):
+		return "privat"
+	default:
+		return ""
+	}
+}
+
+// matchAccountToken returns the account name whose masked token appears in the
+// message. Tokens carry a "*" (e.g. "*0451", "5*85"), which keeps the match from
+// colliding with amounts, balances or dates in the notification text.
+func matchAccountToken(message string, accounts map[string]string) string {
+	for token, account := range accounts {
+		if strings.Contains(message, token) {
+			return account
+		}
+	}
+	return ""
 }
 
 // NotificationHandler turns a parsed bank push notification (app, title, message)
@@ -139,7 +202,7 @@ func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	absoluteAmount := math.Abs(response.Amount)
-	accountName := getAccountNameFromApp(notification.App)
+	accountName := resolveAccountName(notification.App, notification.Message)
 
 	txTime := parseNotificationDate(notification.Date)
 

--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -15,9 +15,7 @@ import (
 	"github.com/morph/internal/taskservice"
 )
 
-// notificationRequest is the payload forwarded by the iOS Shortcut that parses a
-// bank push notification into its source app name, title and body. Date is
-// optional and, when present, sets the transaction date on the deep link.
+// notificationRequest is the bank push notification forwarded by the iOS Shortcut.
 type notificationRequest struct {
 	App     string `json:"app"`
 	Title   string `json:"title"`
@@ -25,12 +23,8 @@ type notificationRequest struct {
 	Date    string `json:"date"`
 }
 
-// parseNotificationDate interprets the optional date forwarded by the Shortcut.
-// It accepts an absolute instant (RFC3339 timestamp carrying its own offset, or a
-// Unix epoch in seconds or milliseconds) or a naive datetime copied from the
-// notification text. Naive values have no timezone, so they are read in the same
-// zone the MoneyWiz deep link renders in. It falls back to the current time when
-// the value is absent or unrecognized.
+// parseNotificationDate parses an RFC3339 instant, a Unix epoch (seconds or
+// milliseconds), or a naive datetime (read as Kyiv time). Falls back to now.
 func parseNotificationDate(raw string) time.Time {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -69,12 +63,10 @@ func parseNotificationDate(raw string) time.Time {
 	return time.Now()
 }
 
-// bbvaAccount is the single MoneyWiz account used for every BBVA notification,
-// regardless of the account number shown in the message.
+// bbvaAccount is the single MoneyWiz account for every BBVA notification.
 const bbvaAccount = "BBVAEur"
 
-// pumbAccounts maps the masked account number as it appears in a PUMB notification
-// (e.g. "Рахунок: *0451") to the MoneyWiz account name.
+// pumbAccounts maps the masked account token in a PUMB notification (e.g. "*0451").
 var pumbAccounts = map[string]string{
 	"*0451": "PumbUAHPlatinum",
 	"*2164": "PumbUAHVirtual",
@@ -82,8 +74,7 @@ var pumbAccounts = map[string]string{
 	"*0404": "PumbEUR",
 }
 
-// privatAccounts maps the masked account token as it appears in a Privat24
-// notification (e.g. "5*85") to the MoneyWiz account name.
+// privatAccounts maps the masked account token in a Privat24 notification (e.g. "5*85").
 var privatAccounts = map[string]string{
 	"5*85": "PrivatOnlineUAH",
 	"3*87": "PrivatOnlineUSD",
@@ -97,11 +88,8 @@ var privatAccounts = map[string]string{
 	"1*89": "PrivatEUR",
 }
 
-// resolveAccountName determines the MoneyWiz account for a notification. The bank
-// is identified from the app name; PUMB and Privat24 then resolve the specific
-// account from the masked account number embedded in the message, while BBVA
-// always maps to a single account. Unrecognized apps/accounts fall back to the
-// app name so the transaction is still delivered (for manual account selection).
+// resolveAccountName picks the MoneyWiz account from the app and the masked
+// account in the message, falling back to the app name when unrecognized.
 func resolveAccountName(app string, message string) string {
 	switch detectBank(app) {
 	case "bbva":
@@ -120,7 +108,7 @@ func resolveAccountName(app string, message string) string {
 	return app
 }
 
-// detectBank maps a notification source app name to a known bank identifier.
+// detectBank maps an app name to a known bank identifier.
 func detectBank(app string) string {
 	normalized := strings.ToLower(strings.TrimSpace(app))
 	switch {
@@ -135,9 +123,8 @@ func detectBank(app string) string {
 	}
 }
 
-// matchAccountToken returns the account name whose masked token appears in the
-// message. Tokens carry a "*" (e.g. "*0451", "5*85"), which keeps the match from
-// colliding with amounts, balances or dates in the notification text.
+// matchAccountToken returns the account whose masked token appears in the message.
+// The "*" in tokens avoids collisions with amounts, balances or dates.
 func matchAccountToken(message string, accounts map[string]string) string {
 	for token, account := range accounts {
 		if strings.Contains(message, token) {
@@ -147,8 +134,8 @@ func matchAccountToken(message string, accounts map[string]string) string {
 	return ""
 }
 
-// NotificationHandler turns a parsed bank push notification (app, title, message)
-// into a categorized MoneyWiz deep link and delivers it to Telegram.
+// NotificationHandler turns a bank push notification into a MoneyWiz deep link
+// and delivers it to Telegram.
 func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("[Morph] Started notification handling...")
 
@@ -167,8 +154,7 @@ func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The notification is forwarded by a Shortcut and carries no chat ID, so
-	// resolve the target chat from configuration.
+	// The notification carries no chat ID, so resolve it from configuration.
 	chatID, err := bot.GetChatID()
 	if err != nil {
 		log.Printf("[Morph] Error getting chat ID: %v", err)

--- a/internal/app/notifications_test.go
+++ b/internal/app/notifications_test.go
@@ -123,9 +123,9 @@ func TestNotificationHandler_HappyPathSchedulesShortLink(t *testing.T) {
 		t.Fatalf("deep link calls = %d, want 1", len(fakes.deepLink.calls))
 	}
 	deepLink := fakes.deepLink.calls[0]
-	// No app:account mapping configured yet, so the app name is used as the account.
-	if deepLink.account != "BBVA ES" {
-		t.Fatalf("deep link account = %q, want %q", deepLink.account, "BBVA ES")
+	// BBVA always maps to a single MoneyWiz account, ignoring the account in the message.
+	if deepLink.account != "BBVAEur" {
+		t.Fatalf("deep link account = %q, want %q", deepLink.account, "BBVAEur")
 	}
 	if deepLink.amount != 79.81 {
 		t.Fatalf("deep link amount = %.2f, want 79.81", deepLink.amount)
@@ -175,20 +175,63 @@ func TestNotificationHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testin
 	}
 }
 
-func TestGetAccountNameFromApp(t *testing.T) {
-	if got := getAccountNameFromApp("Unknown Bank"); got != "Unknown Bank" {
-		t.Fatalf("unknown app account = %q, want app name fallback", got)
+func TestResolveAccountName(t *testing.T) {
+	tests := []struct {
+		name    string
+		app     string
+		message string
+		want    string
+	}{
+		{
+			name:    "BBVA ignores account number in message",
+			app:     "BBVA ES",
+			message: "Se ha cargado en tu cuenta *3297 un adeudo de 79,81 EUR.",
+			want:    "BBVAEur",
+		},
+		{
+			name:    "PUMB UAH platinum from masked account",
+			app:     "ПУМБ",
+			message: "167.36UAH\n26-06-2026 13:13\nРахунок: *0451\nДоступно: 3155.99UAH",
+			want:    "PumbUAHPlatinum",
+		},
+		{
+			name:    "PUMB USD from masked account",
+			app:     "Pumb",
+			message: "Рахунок: *5381\nДоступно: 100.00USD",
+			want:    "PumbUSD",
+		},
+		{
+			name:    "Privat24 online UAH from token",
+			app:     "Privat24",
+			message: "-149₴ Цифрові товари. YouTube Premium\n5*85 22:37\nБал. 429.4₴",
+			want:    "PrivatOnlineUAH",
+		},
+		{
+			name:    "Privat24 EUR from token",
+			app:     "Privat24",
+			message: "-10€ Some payment\n1*89 09:00\nБал. 100€",
+			want:    "PrivatEUR",
+		},
+		{
+			name:    "known bank but unrecognized account falls back to app name",
+			app:     "Pumb",
+			message: "Рахунок: *9999\nДоступно: 1.00UAH",
+			want:    "Pumb",
+		},
+		{
+			name:    "unknown app falls back to app name",
+			app:     "Some Bank",
+			message: "transaction *0451",
+			want:    "Some Bank",
+		},
 	}
 
-	oldMap := appAccountMap
-	appAccountMap = map[string]string{"BBVA ES": "BBVAEUR"}
-	t.Cleanup(func() { appAccountMap = oldMap })
-
-	if got := getAccountNameFromApp("BBVA ES"); got != "BBVAEUR" {
-		t.Fatalf("mapped app account = %q, want BBVAEUR", got)
-	}
-	if got := getAccountNameFromApp("ПУМБ"); got != "ПУМБ" {
-		t.Fatalf("unmapped app account = %q, want app name fallback", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAccountName(tt.app, tt.message); got != tt.want {
+				t.Fatalf("resolveAccountName(%q, ...) = %q, want %q", tt.app, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/app/notifications_test.go
+++ b/internal/app/notifications_test.go
@@ -1,0 +1,242 @@
+package app
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/morph/internal/aiservice"
+)
+
+func TestNotificationHandler_InvalidJSONReturnsBadRequest(t *testing.T) {
+	fakes := installAppFakes(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{invalid`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+	if rr.Body.String() != "Could not parse notification" {
+		t.Fatalf("body = %q, want parse error", rr.Body.String())
+	}
+	if fakes.tasks.connectCount != 0 {
+		t.Fatalf("task service connected %d times, want 0", fakes.tasks.connectCount)
+	}
+}
+
+func TestNotificationHandler_EmptyContentReturnsOK(t *testing.T) {
+	fakes := installAppFakes(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"BBVA"}`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if fakes.tasks.connectCount != 0 {
+		t.Fatalf("task service connected %d times, want 0", fakes.tasks.connectCount)
+	}
+	if fakes.ai.callCount != 0 {
+		t.Fatalf("AI called %d times, want 0", fakes.ai.callCount)
+	}
+}
+
+func TestNotificationHandler_ChatIDFailureReturnsInternalServerError(t *testing.T) {
+	fakes := installAppFakes(t)
+	fakes.bot.chatIDErr = errors.New("missing chat id")
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"BBVA","title":"Recibo cargado","message":"79,81 EUR"}`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+	if rr.Body.String() != "Could not get chat ID" {
+		t.Fatalf("body = %q, want chat ID error", rr.Body.String())
+	}
+	if fakes.tasks.connectCount != 0 {
+		t.Fatalf("task service connected %d times, want 0", fakes.tasks.connectCount)
+	}
+}
+
+func TestNotificationHandler_NoAIResponseSchedulesErrorMessage(t *testing.T) {
+	fakes := installAppFakes(t)
+	fakes.bot.chatID = 909
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"ПУМБ","title":"Списання","message":"167.36UAH"}`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if fakes.tasks.connectCount != 1 || fakes.tasks.closeCount != 1 {
+		t.Fatalf("task connect/close = %d/%d, want 1/1", fakes.tasks.connectCount, fakes.tasks.closeCount)
+	}
+	if len(fakes.tasks.scheduledMessages) != 1 {
+		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
+	}
+	got := fakes.tasks.scheduledMessages[0]
+	if got.ChatID != 909 || got.Text != "No response from AI" || got.ReplyToMessageID != nil {
+		t.Fatalf("scheduled message = %+v, want notification AI error", got)
+	}
+	if fakes.shortURL.callCount != 0 {
+		t.Fatalf("short URL calls = %d, want 0", fakes.shortURL.callCount)
+	}
+}
+
+func TestNotificationHandler_HappyPathSchedulesShortLink(t *testing.T) {
+	fakes := installAppFakes(t)
+	fakes.bot.chatID = 777
+	fakes.ai.response = &aiservice.Response{
+		Category:    "Bills",
+		Subcategory: "Utilities",
+		Amount:      -79.81,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"BBVA ES","title":"Recibo cargado","message":"Se ha cargado en tu cuenta *3297 un adeudo de AIGUES MUNICIPALS DE PATERNA, S.A. de 79,81 EUR.","date":"2026-06-26T13:13:00+03:00"}`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if fakes.ai.callCount != 1 {
+		t.Fatalf("AI calls = %d, want 1", fakes.ai.callCount)
+	}
+	if !strings.Contains(fakes.ai.userPrompt, "BBVA ES") || !strings.Contains(fakes.ai.userPrompt, "Recibo cargado") {
+		t.Fatalf("user prompt = %q, want app and title", fakes.ai.userPrompt)
+	}
+	if len(fakes.deepLink.calls) != 1 {
+		t.Fatalf("deep link calls = %d, want 1", len(fakes.deepLink.calls))
+	}
+	deepLink := fakes.deepLink.calls[0]
+	// No app:account mapping configured yet, so the app name is used as the account.
+	if deepLink.account != "BBVA ES" {
+		t.Fatalf("deep link account = %q, want %q", deepLink.account, "BBVA ES")
+	}
+	if deepLink.amount != 79.81 {
+		t.Fatalf("deep link amount = %.2f, want 79.81", deepLink.amount)
+	}
+	wantDate := time.Date(2026, time.June, 26, 13, 13, 0, 0, time.FixedZone("", 3*60*60))
+	if !deepLink.date.Equal(wantDate) {
+		t.Fatalf("deep link date = %s, want %s", deepLink.date, wantDate)
+	}
+	if len(fakes.shortURL.inputs) != 1 || fakes.shortURL.inputs[0] != "moneywiz://expense" {
+		t.Fatalf("short URL inputs = %v, want moneywiz deep link", fakes.shortURL.inputs)
+	}
+	if len(fakes.tasks.scheduledMessages) != 1 {
+		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
+	}
+	got := fakes.tasks.scheduledMessages[0]
+	wantText := "📲 BBVA ES\nCategory: Bills\nSubcategory: Utilities\nAmount: 79.81\nhttps://short.example/link"
+	if got.Text != wantText {
+		t.Fatalf("scheduled text = %q, want %q", got.Text, wantText)
+	}
+	if got.ChatID != 777 || got.ReplyToMessageID != nil {
+		t.Fatalf("scheduled message = %+v, want chat 777 with no reply", got)
+	}
+}
+
+func TestNotificationHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testing.T) {
+	fakes := installAppFakes(t)
+	fakes.ai.response = &aiservice.Response{
+		Category:    "Multimedia",
+		Subcategory: "Applications",
+		Amount:      149,
+	}
+	fakes.shortURL.err = errors.New("shortener down")
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"Privat24","title":"Privat24","message":"-149₴ Цифрові товари. YouTube Premium"}`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if len(fakes.tasks.scheduledMessages) != 1 {
+		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
+	}
+	if !strings.Contains(fakes.tasks.scheduledMessages[0].Text, "Error shortening URL: shortener down") {
+		t.Fatalf("scheduled text = %q, want shortening error", fakes.tasks.scheduledMessages[0].Text)
+	}
+}
+
+func TestGetAccountNameFromApp(t *testing.T) {
+	if got := getAccountNameFromApp("Unknown Bank"); got != "Unknown Bank" {
+		t.Fatalf("unknown app account = %q, want app name fallback", got)
+	}
+
+	oldMap := appAccountMap
+	appAccountMap = map[string]string{"BBVA ES": "BBVAEUR"}
+	t.Cleanup(func() { appAccountMap = oldMap })
+
+	if got := getAccountNameFromApp("BBVA ES"); got != "BBVAEUR" {
+		t.Fatalf("mapped app account = %q, want BBVAEUR", got)
+	}
+	if got := getAccountNameFromApp("ПУМБ"); got != "ПУМБ" {
+		t.Fatalf("unmapped app account = %q, want app name fallback", got)
+	}
+}
+
+func TestParseNotificationDate(t *testing.T) {
+	kyiv, err := time.LoadLocation("Europe/Kyiv")
+	if err != nil {
+		t.Fatalf("load Kyiv location: %v", err)
+	}
+
+	t.Run("RFC3339 absolute instant", func(t *testing.T) {
+		want := time.Date(2026, time.June, 26, 13, 13, 0, 0, time.FixedZone("", 3*60*60))
+		if got := parseNotificationDate("2026-06-26T13:13:00+03:00"); !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("unix epoch seconds", func(t *testing.T) {
+		if got := parseNotificationDate("1746194127"); !got.Equal(time.Unix(1746194127, 0)) {
+			t.Fatalf("got %s, want unix 1746194127", got)
+		}
+	})
+
+	t.Run("unix epoch milliseconds", func(t *testing.T) {
+		if got := parseNotificationDate("1746194127000"); !got.Equal(time.Unix(1746194127, 0)) {
+			t.Fatalf("got %s, want unix 1746194127", got)
+		}
+	})
+
+	t.Run("naive notification text in Kyiv time", func(t *testing.T) {
+		want := time.Date(2026, time.June, 26, 13, 13, 0, 0, kyiv)
+		if got := parseNotificationDate("26-06-2026 13:13"); !got.Equal(want) {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("empty falls back to now", func(t *testing.T) {
+		before := time.Now()
+		got := parseNotificationDate("")
+		if got.Before(before) || got.After(time.Now()) {
+			t.Fatalf("got %s, want approximately now", got)
+		}
+	})
+
+	t.Run("garbage falls back to now", func(t *testing.T) {
+		before := time.Now()
+		got := parseNotificationDate("not a date")
+		if got.Before(before) || got.After(time.Now()) {
+			t.Fatalf("got %s, want approximately now", got)
+		}
+	})
+}

--- a/scripts/deploy_functions.sh
+++ b/scripts/deploy_functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FUNCTIONS=("cashHandler" "monoHandler" "monoWebHook" "sendMessage")
+FUNCTIONS=("cashHandler" "monoHandler" "monoWebHook" "sendMessage" "notificationHandler")
 RUNTIME="go125"
 PROJECT_ID=$MORPH_PROJECT_ID
 MEMORY="256MB"


### PR DESCRIPTION
## Summary

Adds a new `notificationHandler` Cloud Function that turns a parsed bank push notification (forwarded by an iOS 27 Shortcut) into a categorized MoneyWiz deep link delivered via Telegram — mirroring the existing `cashHandler`/`monoHandler` flow.

**Endpoint:** `POST /notificationHandler`

```json
{ "app": "BBVA ES", "title": "Recibo cargado", "message": "Se ha cargado en tu cuenta *3297 ... de 79,81 EUR.", "date": "2026-06-26T13:13:00+03:00" }
```

**Flow:**
1. Parses `app`, `title`, `message`, optional `date` (400 on bad JSON; 200 no-op when title & message are empty).
2. Resolves the target chat via `bot.GetChatID()` (the notification carries no chat ID) — 500 if unset.
3. Classifies via AI into category / subcategory / amount (reuses the shared `aiservice.Response` schema).
4. Resolves the MoneyWiz account, generates a deep link, shortens it, and schedules the Telegram message via Cloud Tasks.

## Account mapping

`resolveAccountName(app, message)` identifies the bank from the app name (case-insensitive; handles `пумб`/`Privat24`/`BBVA ES`) and:
- **BBVA** → always `BBVAEur` (account number in the message is ignored).
- **PUMB** → per card from the masked token in the message (`*0451 → PumbUAHPlatinum`, `*2164`, `*5381`, `*0404`).
- **Privat24** → per card from the token (`5*85 → PrivatOnlineUAH`, plus 9 more).
- **Fallback** → unrecognized app/account uses the app name (transaction still delivered for manual selection) and logs a warning.

Matching is anchored on the `*`-bearing token so it can't collide with the amount, balance, or date in the notification text.

## Date handling

Optional `date` accepts an absolute instant (RFC3339 with offset, or Unix epoch seconds/ms) or a naive datetime copied from the notification text (read as Europe/Kyiv — the zone the deep link renders in, avoiding a wrong-time-of-day shift). Falls back to `time.Now()` when absent or unrecognized.

## Changes

- `internal/app/notifications.go`, `internal/app/notifications_test.go` (new)
- Registered `notificationHandler` in `function.go`, `cmd/main.go`, and `scripts/deploy_functions.sh`
- Documented the endpoint in `README.md`

## Testing

`go build ./...`, `go vet`, and `go test ./...` all pass. New tests cover the handler flow (invalid JSON, empty content, chat-ID failure, no-AI-response, happy path, short-URL error), account resolution across all three banks + both fallbacks, and date parsing across all formats.

## Notes

- PUMB tokens are encoded with the leading `*` (e.g. `*0451`), matching the `Рахунок: *0451` notification format. If PUMB ever renders the account differently, the matcher would fall back — easy to loosen with a sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)