### PR TITLE
Ignore non-transaction notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The application consists of five main Google Cloud Functions that work together 
   `date` is optional. It accepts an absolute instant (RFC3339/ISO 8601 with timezone, or a Unix epoch in seconds/milliseconds) or a naive datetime copied from the notification text (interpreted as Europe/Kyiv). When omitted or unrecognized, the current server time is used.
 - **Flow**:
   1. Receives the source app name, notification title, message and optional date
-  2. Uses AI to classify the notification into a category, subcategory, and amount
+  2. Uses AI to classify the notification into a category, subcategory, and amount, and to decide whether it is an actual transaction — non-transaction pushes (promotional, informational, security alerts) are silently ignored
   3. Resolves the MoneyWiz account name from the source app and the masked account number in the message — BBVA maps to a single account, while PUMB (`Рахунок: *0451`) and Privat24 (`5*85`) resolve per card (see `resolveAccountName` in `internal/app/notifications.go`). Unrecognized apps/accounts fall back to the app name.
   4. Generates a MoneyWiz deep link (with the provided date) and shortens it
   5. Schedules a Telegram message with the categorized transaction and deep link

--- a/internal/aiservice/aiservice.go
+++ b/internal/aiservice/aiservice.go
@@ -3,9 +3,10 @@ package aiservice
 import "context"
 
 type Response struct {
-	Category    string  `json:"category"`
-	Subcategory string  `json:"subcategory"`
-	Amount      float64 `json:"amount"`
+	Category      string  `json:"category"`
+	Subcategory   string  `json:"subcategory"`
+	Amount        float64 `json:"amount"`
+	IsTransaction bool    `json:"isTransaction"`
 }
 
 type AIService interface {

--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -170,7 +170,7 @@ func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 	categories := category.GetCategoriesInJSON()
 	hints := category.GetHintsInJSON()
 
-	systemPrompt := "You are a data analyst. Your task is to classify a bank push notification into a category, subcategory, and amount. You MUST ONLY use the categories and subcategories provided below—do not invent new ones. If the input does not match any, use 'Other' for category and an empty string for subcategory. Extract the transaction amount from the notification text as a number. Output a single-line JSON object with only these fields: category, subcategory, amount. Example of the output: {\"category\": \"Children\", \"subcategory\": \"Vocal\", \"amount\": 400.0}. Categories and subcategories: " + categories + " Hints: " + hints + " IMPORTANT: Do not add any explanation or extra text. Only output the JSON object."
+	systemPrompt := "You are a data analyst. Your task is to analyze a bank push notification and classify it into a category, subcategory, and amount. First decide whether the notification represents an actual financial transaction (a debit or credit on an account): set isTransaction to false for anything that is not a transaction, such as promotional or marketing messages, security or login alerts, or general informational messages, and set it to true only for real transactions. You MUST ONLY use the categories and subcategories provided below—do not invent new ones. If the input does not match any, use 'Other' for category and an empty string for subcategory. Extract the transaction amount from the notification text as a number (use 0 when there is no transaction). Output a single-line JSON object with only these fields: category, subcategory, amount, isTransaction. Example of the output: {\"category\": \"Children\", \"subcategory\": \"Vocal\", \"amount\": 400.0, \"isTransaction\": true}. Categories and subcategories: " + categories + " Hints: " + hints + " IMPORTANT: Do not add any explanation or extra text. Only output the JSON object."
 	userPrompt := fmt.Sprintf("Classify this bank push notification.\nApp: %s\nTitle: %s\nMessage: %s", notification.App, notification.Title, notification.Message)
 
 	response := aiService.Request("Morph", "Translates a bank push notification into: Category, Subcategory, Amount", systemPrompt, userPrompt, &ctx)
@@ -182,6 +182,14 @@ func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 			ReplyToMessageID: nil,
 		}
 		taskService.ScheduleMessage(&ctx, scheduledMessage, time.Now())
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+		return
+	}
+
+	// Promotional, informational and other non-transaction pushes are dropped.
+	if !response.IsTransaction {
+		log.Printf("[Morph] Notification is not a transaction, ignoring")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 		return

--- a/internal/app/notifications_test.go
+++ b/internal/app/notifications_test.go
@@ -100,9 +100,10 @@ func TestNotificationHandler_HappyPathSchedulesShortLink(t *testing.T) {
 	fakes := installAppFakes(t)
 	fakes.bot.chatID = 777
 	fakes.ai.response = &aiservice.Response{
-		Category:    "Bills",
-		Subcategory: "Utilities",
-		Amount:      -79.81,
+		Category:      "Bills",
+		Subcategory:   "Utilities",
+		Amount:        -79.81,
+		IsTransaction: true,
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"BBVA ES","title":"Recibo cargado","message":"Se ha cargado en tu cuenta *3297 un adeudo de AIGUES MUNICIPALS DE PATERNA, S.A. de 79,81 EUR.","date":"2026-06-26T13:13:00+03:00"}`))
@@ -153,9 +154,10 @@ func TestNotificationHandler_HappyPathSchedulesShortLink(t *testing.T) {
 func TestNotificationHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testing.T) {
 	fakes := installAppFakes(t)
 	fakes.ai.response = &aiservice.Response{
-		Category:    "Multimedia",
-		Subcategory: "Applications",
-		Amount:      149,
+		Category:      "Multimedia",
+		Subcategory:   "Applications",
+		Amount:        149,
+		IsTransaction: true,
 	}
 	fakes.shortURL.err = errors.New("shortener down")
 
@@ -172,6 +174,37 @@ func TestNotificationHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testin
 	}
 	if !strings.Contains(fakes.tasks.scheduledMessages[0].Text, "Error shortening URL: shortener down") {
 		t.Fatalf("scheduled text = %q, want shortening error", fakes.tasks.scheduledMessages[0].Text)
+	}
+}
+
+func TestNotificationHandler_NonTransactionIsIgnored(t *testing.T) {
+	fakes := installAppFakes(t)
+	fakes.ai.response = &aiservice.Response{
+		Category:      "Other",
+		Subcategory:   "",
+		Amount:        0,
+		IsTransaction: false,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/notificationHandler", strings.NewReader(`{"app":"Privat24","title":"Privat24","message":"🎉 Отримайте 5% кешбек цими вихідними!"}`))
+	rr := httptest.NewRecorder()
+
+	NotificationHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if fakes.tasks.connectCount != 1 || fakes.tasks.closeCount != 1 {
+		t.Fatalf("task connect/close = %d/%d, want 1/1", fakes.tasks.connectCount, fakes.tasks.closeCount)
+	}
+	if fakes.deepLink.callCount != 0 {
+		t.Fatalf("deep link calls = %d, want 0", fakes.deepLink.callCount)
+	}
+	if fakes.shortURL.callCount != 0 {
+		t.Fatalf("short URL calls = %d, want 0", fakes.shortURL.callCount)
+	}
+	if len(fakes.tasks.scheduledMessages) != 0 {
+		t.Fatalf("scheduled messages = %d, want 0", len(fakes.tasks.scheduledMessages))
 	}
 }
 


### PR DESCRIPTION
## Summary

Filters out non-transaction bank push notifications (promos, marketing, security/login alerts, informational messages) so they don't produce a noisy `0.00 / Other` MoneyWiz deep link in Telegram.

This is the same change as #80, which accidentally merged into the `feature/notification-handler` branch instead of `main` (a stacked-PR base that wasn't auto-retargeted). This PR re-applies it cleanly on top of `main`.

## How it works

- Adds an `IsTransaction` field to `aiservice.Response`. The notification prompt now asks the model to first decide whether the push is an actual financial transaction (a debit/credit) vs. a promo/alert/info message.
- `NotificationHandler` drops non-transactions right after classification — returns `200 OK`, logs `Notification is not a transaction, ignoring`, and sends nothing to Telegram.
- `cashHandler`/`monoHandler` never read the flag, so they are unaffected.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. Added `TestNotificationHandler_NonTransactionIsIgnored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)