### PR TITLE
Add PUMB card tokens and raw notification logging

### DIFF
--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"net/http"
@@ -69,9 +70,13 @@ const bbvaAccount = "BBVAEur"
 // pumbAccounts maps the masked account token in a PUMB notification (e.g. "*0451").
 var pumbAccounts = map[string]string{
 	"*0451": "PumbUAHPlatinum",
+	"*5353": "PumbUAHPlatinum",
 	"*2164": "PumbUAHVirtual",
+	"*8043": "PumbUAHVirtual",
 	"*5381": "PumbUSD",
+	"*2985": "PumbUSD",
 	"*0404": "PumbEUR",
+	"*4249": "PumbEUR",
 }
 
 // privatAccounts maps the masked account token in a Privat24 notification (e.g. "5*85").
@@ -139,13 +144,26 @@ func matchAccountToken(message string, accounts map[string]string) string {
 func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("[Morph] Started notification handling...")
 
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("[Morph] Could not read notification body %s", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Could not read notification"))
+		return
+	}
+
+	// Log the raw payload so we can see exactly what the iOS Shortcut sends.
+	log.Printf("[Morph] Raw notification body (%d bytes): %s", len(body), string(body))
+
 	var notification notificationRequest
-	if err := json.NewDecoder(r.Body).Decode(&notification); err != nil {
+	if err := json.Unmarshal(body, &notification); err != nil {
 		log.Printf("[Morph] Could not parse notification %s", err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("Could not parse notification"))
 		return
 	}
+
+	log.Printf("[Morph] Parsed notification: app=%q title=%q message=%q date=%q", notification.App, notification.Title, notification.Message, notification.Date)
 
 	if notification.Title == "" && notification.Message == "" {
 		log.Printf("[Morph] No content in notification")

--- a/internal/app/notifications_test.go
+++ b/internal/app/notifications_test.go
@@ -228,6 +228,12 @@ func TestResolveAccountName(t *testing.T) {
 			want:    "PumbUAHPlatinum",
 		},
 		{
+			name:    "PUMB UAH platinum from secondary card token",
+			app:     "ПУМБ",
+			message: "25.60EUR / 1319.18UAH (курс 51.53)\nGASTROBAR B13 VALENCIA ES\n30-06-2026 12:46\nКартка: *5353...",
+			want:    "PumbUAHPlatinum",
+		},
+		{
 			name:    "PUMB USD from masked account",
 			app:     "Pumb",
 			message: "Рахунок: *5381\nДоступно: 100.00USD",


### PR DESCRIPTION
## Summary

- Map the additional PUMB card tokens to their MoneyWiz accounts so notifications from these cards resolve correctly instead of falling back to the app name (`ПУМБ`) in the deep link:
  - `*5353` → `PumbUAHPlatinum`
  - `*8043` → `PumbUAHVirtual`
  - `*2985` → `PumbUSD`
  - `*4249` → `PumbEUR`
- Log the **raw request body** and the **parsed notification fields** at the top of `NotificationHandler`, to diagnose notifications that arrive with empty `title`/`message` (e.g. when the iOS Shortcut forwards no content — currently this just logs "No content in notification" with no visibility into what was actually sent).

## Why

A real PUMB purchase (card `*5353`) produced a deep link with `account=ПУМБ` because the token wasn't in `pumbAccounts`, so `resolveAccountName` fell back to the app name. These cards now map to the correct accounts.

The logging change converts the body read from `json.NewDecoder(r.Body)` to `io.ReadAll` + `json.Unmarshal` so the raw payload can be logged before parsing — behavior is otherwise identical.

## Testing

- `go build ./...`
- `go test ./internal/app/` (green; added a `TestResolveAccountName` case using the real `*5353` notification text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)