### PR TITLE
Add MIT license and fix README for public release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Maksym Bilan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following environment variables are required for the application to function
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/yourusername/morph.git
+git clone https://github.com/maximbilan/morph.git
 cd morph
 ```
 
@@ -243,3 +243,7 @@ The project includes GitHub Actions workflows for:
 - `cleanup_shortio_links.sh`: Cleans up expired Short.io links
 - `update_deps.sh`: Updates Go dependencies
 - `create_credentials_json.sh`: Creates credentials JSON for local development
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Prepares the repo for being promoted as open source (it's already public).

## Changes
- **Add MIT `LICENSE`** — without a license the project isn't legally open source; MIT is the conventional no-friction choice for a personal project. Copyright: `2026 Maksym Bilan`.
- **Add a License section** to the README.
- **Fix the clone URL** in the README (`yourusername` → `maximbilan`).

## Note
Repo description and topics are being set separately via the GitHub API (not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)