### PR TITLE
Add HTTP timeouts and graceful URL-shortener fallback

### DIFF
--- a/internal/app/handler_flow_test.go
+++ b/internal/app/handler_flow_test.go
@@ -263,7 +263,7 @@ func TestCashHandler_HappyPathUsesCashEURAndSchedulesShortLink(t *testing.T) {
 	}
 }
 
-func TestCashHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testing.T) {
+func TestCashHandler_ShortURLErrorFallsBackToRawDeepLink(t *testing.T) {
 	fakes := installAppFakes(t)
 	fakes.bot.message = &botservice.BotMessage{
 		MessageID: 1,
@@ -288,8 +288,12 @@ func TestCashHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testing.T) {
 	if len(fakes.tasks.scheduledMessages) != 1 {
 		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
 	}
-	if !strings.Contains(fakes.tasks.scheduledMessages[0].Text, "Error shortening URL: shortener down") {
-		t.Fatalf("scheduled text = %q, want shortening error", fakes.tasks.scheduledMessages[0].Text)
+	got := fakes.tasks.scheduledMessages[0].Text
+	if !strings.Contains(got, "moneywiz://expense") {
+		t.Fatalf("scheduled text = %q, want raw deep link fallback", got)
+	}
+	if strings.Contains(got, "shortener down") {
+		t.Fatalf("scheduled text = %q, should not leak the shortener error", got)
 	}
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -15,6 +15,20 @@ import (
 
 const cashAccountName = "CashEUR"
 
+// appendShortLink shortens deepLink and appends the result to text on a new
+// line. If shortening fails it logs the full error and falls back to the raw
+// deep link, so the user still receives a usable link instead of the
+// shortener's (potentially huge) error page.
+func appendShortLink(text, deepLink string) string {
+	url, err := shortURLService.Shorten(deepLink)
+	if err != nil {
+		log.Printf("[Morph] Error shortening URL: %v", err)
+		return text + "\n⚠️ Link not shortened:\n" + deepLink
+	}
+	log.Printf("[Morph] Shortened URL: %s", url)
+	return text + "\n" + url
+}
+
 func CashHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println("[Morph] Started cash handling...")
 
@@ -66,14 +80,7 @@ func CashHandler(w http.ResponseWriter, r *http.Request) {
 	text := "Category: " + response.Category + "\nSubcategory: " + response.Subcategory + "\nAmount: " + fmt.Sprintf("%.2f", absoluteAmount)
 	deepLink := deepLinkGenerator.Create(response.Category, response.Subcategory, cashAccountName, absoluteAmount, time.Now())
 
-	url, err := shortURLService.Shorten(deepLink)
-	if err != nil {
-		log.Printf("[Morph] Error shortening URL: %v", err)
-		text += "\nError shortening URL: " + err.Error()
-	} else {
-		log.Printf("[Morph] Shortened URL: %s", url)
-		text += "\n" + url
-	}
+	text = appendShortLink(text, deepLink)
 
 	log.Printf("[Morph] Sending message to chat %d", message.ChatID)
 
@@ -153,7 +160,6 @@ func MonoHandler(w http.ResponseWriter, r *http.Request) {
 	if transaction.IsRefund {
 		linkMsg += "\n🔄 Refund"
 	}
-	linkMsg += "\n"
 
 	// Determine the transaction time. Mono API may provide time in seconds or milliseconds since epoch.
 	// Use a heuristic: treat large values as milliseconds.
@@ -170,14 +176,7 @@ func MonoHandler(w http.ResponseWriter, r *http.Request) {
 
 	deepLink := deepLinkGenerator.Create(response.Category, response.Subcategory, accountName, absoluteAmount, txTime)
 
-	url, err := shortURLService.Shorten(deepLink)
-	if err != nil {
-		log.Printf("[Morph] Error shortening URL: %v", err)
-		linkMsg += "\nError shortening URL: " + err.Error()
-	} else {
-		log.Printf("[Morph] Shortened URL: %s", url)
-		linkMsg += url
-	}
+	linkMsg = appendShortLink(linkMsg, deepLink)
 
 	log.Printf("[Morph] Sending message to chat %d", chatId)
 

--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -223,14 +223,7 @@ func NotificationHandler(w http.ResponseWriter, r *http.Request) {
 
 	deepLink := deepLinkGenerator.Create(response.Category, response.Subcategory, accountName, absoluteAmount, txTime)
 
-	url, err := shortURLService.Shorten(deepLink)
-	if err != nil {
-		log.Printf("[Morph] Error shortening URL: %v", err)
-		text += "\nError shortening URL: " + err.Error()
-	} else {
-		log.Printf("[Morph] Shortened URL: %s", url)
-		text += "\n" + url
-	}
+	text = appendShortLink(text, deepLink)
 
 	log.Printf("[Morph] Sending message to chat %d", chatID)
 

--- a/internal/app/notifications_test.go
+++ b/internal/app/notifications_test.go
@@ -151,7 +151,7 @@ func TestNotificationHandler_HappyPathSchedulesShortLink(t *testing.T) {
 	}
 }
 
-func TestNotificationHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testing.T) {
+func TestNotificationHandler_ShortURLErrorFallsBackToRawDeepLink(t *testing.T) {
 	fakes := installAppFakes(t)
 	fakes.ai.response = &aiservice.Response{
 		Category:      "Multimedia",
@@ -172,8 +172,12 @@ func TestNotificationHandler_ShortURLErrorIsIncludedInScheduledMessage(t *testin
 	if len(fakes.tasks.scheduledMessages) != 1 {
 		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
 	}
-	if !strings.Contains(fakes.tasks.scheduledMessages[0].Text, "Error shortening URL: shortener down") {
-		t.Fatalf("scheduled text = %q, want shortening error", fakes.tasks.scheduledMessages[0].Text)
+	got := fakes.tasks.scheduledMessages[0].Text
+	if !strings.Contains(got, "moneywiz://expense") {
+		t.Fatalf("scheduled text = %q, want raw deep link fallback", got)
+	}
+	if strings.Contains(got, "shortener down") {
+		t.Fatalf("scheduled text = %q, should not leak the shortener error", got)
 	}
 }
 

--- a/third_party/mono/mono.go
+++ b/third_party/mono/mono.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 )
 
 // StatementItem represents a single transaction in Mono
@@ -147,7 +148,7 @@ func GetClientInfo() (*ClientInfo, error) {
 
 	req.Header.Set("X-Token", apiKey)
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)

--- a/third_party/shortio/shortio.go
+++ b/third_party/shortio/shortio.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 )
 
 type ShortIO struct{}
@@ -39,7 +40,7 @@ func (s ShortIO) Shorten(URL string) (string, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", os.Getenv("MORPH_REDIRECT_KEY"))
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %v", err)


### PR DESCRIPTION
## Problem

The URL shortener (short.io, served behind AWS CloudFront) can return an **HTTP 504 Gateway Timeout**. When that happened, Morph appended the shortener's entire raw response body — a full CloudFront HTML error page — verbatim into the Telegram message, producing an unreadable wall of text for every affected transaction.

The transaction itself was categorized fine; only the "make a short link" step failed, but the failure was surfaced badly.

## Changes

- **HTTP timeouts:** add a 10s timeout to the short.io and Monobank HTTP clients (`&http.Client{}` had no timeout), so a hanging provider can't block the request indefinitely.
- **Graceful fallback:** new shared `appendShortLink` helper. On shortening failure it logs the full error but appends a short note plus the **raw MoneyWiz deep link**, so the transaction message stays usable instead of dumping a provider error page:
  ```
  ⚠️ Link not shortened:
  moneywiz://expense?amount=2500.00&account=...&save=true
  ```
- Replaced the duplicated inline shorten-or-error blocks in `CashHandler`, `MonoHandler`, and `NotificationHandler` with the helper (also dropped a redundant trailing newline in `MonoHandler`).
- Updated the two shortener-error tests to assert the raw deep-link fallback and that the shortener error is no longer leaked into the message.

## Note

This does not prevent short.io outages, but it makes Morph degrade gracefully: you still get a categorized transaction with a usable (unshortened) link, and the full error goes to the logs for debugging.

## Testing

- `go build ./...`
- `go test ./...` (all green)
- `go vet ./...` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)