### PR TITLE
Correct Privat24 masked-card tokens in account map

### DIFF
--- a/internal/app/notifications.go
+++ b/internal/app/notifications.go
@@ -82,15 +82,15 @@ var pumbAccounts = map[string]string{
 // privatAccounts maps the masked account token in a Privat24 notification (e.g. "5*85").
 var privatAccounts = map[string]string{
 	"5*85": "PrivatOnlineUAH",
-	"3*87": "PrivatOnlineUSD",
-	"2*62": "PrivatOnlineEUR",
+	"5*87": "PrivatOnlineUSD",
+	"4*62": "PrivatOnlineEUR",
 	"5*30": "StartupPrivatUAH",
-	"9*88": "StartupPrivatUSD",
-	"6*64": "PrivatEntrepreneurUAH",
-	"6*31": "PrivatPaymentsUAH",
-	"6*99": "PrivatUniversalUAH",
-	"0*07": "PrivatPaymentsUSD",
-	"1*89": "PrivatEUR",
+	"5*88": "StartupPrivatUSD",
+	"5*64": "PrivatEntrepreneurUAH",
+	"5*31": "PrivatPaymentsUAH",
+	"4*99": "PrivatUniversalUAH",
+	"5*07": "PrivatPaymentsUSD",
+	"5*89": "PrivatEUR",
 }
 
 // resolveAccountName picks the MoneyWiz account from the app and the masked

--- a/internal/app/notifications_test.go
+++ b/internal/app/notifications_test.go
@@ -252,7 +252,7 @@ func TestResolveAccountName(t *testing.T) {
 		{
 			name:    "Privat24 EUR from token",
 			app:     "Privat24",
-			message: "-10€ Some payment\n1*89 09:00\nБал. 100€",
+			message: "-10€ Some payment\n5*89 09:00\nБал. 100€",
 			want:    "PrivatEUR",
 		},
 		{


### PR DESCRIPTION
## What

Fixes the masked-card tokens in `privatAccounts` so Privat24 notifications resolve to the correct MoneyWiz account.

Several tokens didn't match the real masked card numbers (most Privat24 cards start with `5*`), so those transactions fell back to the `"Privat24"` app name in `resolveAccountName` instead of a real account — meaning the deep link had no proper account attached.

## Why now

Surfaced while manually recovering a lost transaction (`-6.49$ … Spotify` on card `5*87`) that an iOS Shortcut dropped with empty content. The USD online card `5*87` wasn't in the map (it had `3*87`), so it resolved to the fallback. Auditing the rest of the map turned up several more mismatched tokens.

## Changes

- `internal/app/notifications.go` — corrected the `privatAccounts` token → account mappings.
- `internal/app/notifications_test.go` — updated the EUR case in `TestResolveAccountName` to the corrected token (`5*89`).

## Verification

- `go build ./...` ✅
- `go test ./internal/app/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)