### PR TITLE
Switch AI model to gpt-5.4-nano for transaction analysis

### DIFF
--- a/third_party/openai/client.go
+++ b/third_party/openai/client.go
@@ -60,7 +60,9 @@ func (service OpenAI) Request(name string, description string, systemPrompt stri
 				JSONSchema: schemaParam,
 			},
 		},
-		Model: openai.ChatModelGPT4o,
+		// gpt-5.4-nano: best quality/cost/speed for closed-taxonomy
+		// transaction classification with structured JSON output.
+		Model: "gpt-5.4-nano",
 	})
 
 	response := aiservice.Response{}


### PR DESCRIPTION
## Summary
- Replace hardcoded `gpt-4o` with `gpt-5.4-nano` in the OpenAI client used by all transaction analysis paths (cash free-text, Monobank, bank push notifications).
- Targets a better quality/cost/speed balance for closed-taxonomy classification with strict JSON schema: ~10× cheaper than gpt-4o, purpose-built for classification/extraction, with structured outputs and default `reasoning.effort=none` for low latency.

## Test plan
- [ ] Deploy or run locally with a valid `MORPH_AI_KEY`
- [ ] Exercise cash free-text classification via Telegram and confirm category/subcategory/amount + deep link
- [ ] Exercise a Monobank transaction path (or scheduled mono handler payload) and confirm categorization
- [ ] Exercise a bank push notification that is a real transaction and one promo/security alert (`isTransaction: false` should skip messaging)
- [ ] Confirm Cloud Function logs show successful OpenAI responses and reasonable latency (`[OpenAI] Request took ...`)