### PR TITLE
Update mcc dependency to 0.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/cloudtasks v1.19.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.9.2
 	github.com/invopop/jsonschema v0.14.0
-	github.com/maximbilan/mcc v0.0.0-20260701123126-192cf0805b8e
+	github.com/maximbilan/mcc v0.0.0-20260809124657-e7db4802e55b
 	github.com/openai/openai-go v1.12.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8i
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/maximbilan/mcc v0.0.0-20260701123126-192cf0805b8e h1:E6j0r7ern4h8kU7sWHlu9OSYb2d6ALxWrNKemN55s20=
-github.com/maximbilan/mcc v0.0.0-20260701123126-192cf0805b8e/go.mod h1:Lr5AI9PLaxugjJdtAUIPBtEF6lNjRiYB3B6NW4as7OU=
+github.com/maximbilan/mcc v0.0.0-20260809124657-e7db4802e55b h1:cZnReI4Ib1J4D0rzYdI+Jm6A6rINwLYorFWppP/k/I8=
+github.com/maximbilan/mcc v0.0.0-20260809124657-e7db4802e55b/go.mod h1:Lr5AI9PLaxugjJdtAUIPBtEF6lNjRiYB3B6NW4as7OU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
Bumps `github.com/maximbilan/mcc` to [0.1.4](https://github.com/maximbilan/mcc/releases/tag/0.1.4).

Fixes the `⚠️ MCC code not found: 9405` notification — `9405` (*Intra-government purchases -- government only*, ISO 18245) is now in the lookup table ([maximbilan/mcc#9](https://github.com/maximbilan/mcc/pull/9)).

This release also picks up `6513` (*Real estate agents and managers -- rentals*), which was merged upstream but never tagged.

`go build ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)