### PR TITLE
Upgrade Cloud Functions runtime to go126

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Morph is a serverless application built on Google Cloud Functions that helps man
 
 ## Prerequisites
 
-- Go 1.25.0 or later
+- Go 1.26.0 or later
 - Google Cloud Platform account with billing enabled
 - Google Cloud SDK (`gcloud`) installed and configured
 - Monobank API token

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/morph
 
-go 1.25.8
+go 1.26.0
 
 require (
 	cloud.google.com/go/cloudtasks v1.19.0

--- a/scripts/deploy_functions.sh
+++ b/scripts/deploy_functions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 FUNCTIONS=("cashHandler" "monoHandler" "monoWebHook" "sendMessage" "notificationHandler")
-RUNTIME="go125"
+RUNTIME="go126"
 PROJECT_ID=$MORPH_PROJECT_ID
 MEMORY="256MB"
 TIMEOUT=180 # 3 minutes


### PR DESCRIPTION
## Summary

Google Cloud is showing a deprecation banner for the `go125` runtime: deprecated **Oct 1, 2026**, decommissioned **Apr 1, 2027**. `gcloud functions runtimes list` confirms `go126` is **GA** for 2nd gen, so this moves us onto it ahead of the deadline.

- `scripts/deploy_functions.sh` — `RUNTIME` `go125` → `go126`
- `go.mod` — `go 1.25.8` → `go 1.26.0`
- `README.md` — prerequisite bumped to Go 1.26.0

The `go` directive is `1.26.0` rather than a patch pin (`1.26.x`) so it can't end up newer than the GCF builder's bundled toolchain and force a toolchain download mid-build. The weekly **Update Dependencies** job will likely bump it to a patch version on its next run, as it did for 1.25.

No source changes were needed — nothing in the tree depends on 1.25-specific behavior.

## Test plan

- [x] `go mod tidy` — no `go.mod`/`go.sum` changes beyond the version line
- [x] `go build ./...` passes on Go 1.26.5
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (app, category, taskservice, moneywiz, mono, telegram)
- [ ] CI green (`build_and_test.yml` picks the version up via `go-version-file: go.mod`)
- [ ] After merge: run `./scripts/deploy_functions.sh` to redeploy all five functions and confirm the banner clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)