### PR TITLE
Label Monobank and Cash messages with their source

### DIFF
--- a/internal/app/handler_flow_test.go
+++ b/internal/app/handler_flow_test.go
@@ -254,7 +254,7 @@ func TestCashHandler_HappyPathUsesCashEURAndSchedulesShortLink(t *testing.T) {
 		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
 	}
 	got := fakes.tasks.scheduledMessages[0]
-	wantText := "Category: Food\nSubcategory: Shop\nAmount: 42.50\nhttps://short.example/link"
+	wantText := "💵 Cash\nCategory: Food\nSubcategory: Shop\nAmount: 42.50\nhttps://short.example/link"
 	if got.Text != wantText {
 		t.Fatalf("scheduled text = %q, want %q", got.Text, wantText)
 	}
@@ -366,11 +366,9 @@ func TestMonoHandler_HappyPathUsesAccountMappingRefundAndMillisecondTime(t *test
 		t.Fatalf("scheduled messages = %d, want 1", len(fakes.tasks.scheduledMessages))
 	}
 	got := fakes.tasks.scheduledMessages[0]
-	if !strings.Contains(got.Text, "🔄 Refund") {
-		t.Fatalf("scheduled text = %q, want refund marker", got.Text)
-	}
-	if !strings.Contains(got.Text, "https://short.example/link") {
-		t.Fatalf("scheduled text = %q, want short link", got.Text)
+	wantText := "📲 Monobank\nCategory: Transport\nSubcategory: Taxi\nAmount: 176.00\n🔄 Refund\nhttps://short.example/link"
+	if got.Text != wantText {
+		t.Fatalf("scheduled text = %q, want %q", got.Text, wantText)
 	}
 }
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -15,6 +15,13 @@ import (
 
 const cashAccountName = "CashEUR"
 
+// monoLabel and cashLabel head their messages so every entry in the Telegram
+// chat says which bank (or wallet) it came from.
+const (
+	monoLabel = "Monobank"
+	cashLabel = "Cash"
+)
+
 // appendShortLink shortens deepLink and appends the result to text on a new
 // line. If shortening fails it logs the full error and falls back to the raw
 // deep link, so the user still receives a usable link instead of the
@@ -77,7 +84,7 @@ func CashHandler(w http.ResponseWriter, r *http.Request) {
 	absoluteAmount := math.Abs(response.Amount)
 
 	log.Printf("[Morph] Response: %s %s %f", response.Category, response.Subcategory, absoluteAmount)
-	text := "Category: " + response.Category + "\nSubcategory: " + response.Subcategory + "\nAmount: " + fmt.Sprintf("%.2f", absoluteAmount)
+	text := fmt.Sprintf("💵 %s\nCategory: %s\nSubcategory: %s\nAmount: %.2f", cashLabel, response.Category, response.Subcategory, absoluteAmount)
 	deepLink := deepLinkGenerator.Create(response.Category, response.Subcategory, cashAccountName, absoluteAmount, time.Now())
 
 	text = appendShortLink(text, deepLink)
@@ -156,7 +163,7 @@ func MonoHandler(w http.ResponseWriter, r *http.Request) {
 	absoluteAmount := math.Abs(response.Amount)
 
 	log.Printf("[Morph] Response: %s %s %f", response.Category, response.Subcategory, absoluteAmount)
-	linkMsg := fmt.Sprintf("Category: %s\nSubcategory: %s\nAmount: %.2f", response.Category, response.Subcategory, absoluteAmount)
+	linkMsg := fmt.Sprintf("📲 %s\nCategory: %s\nSubcategory: %s\nAmount: %.2f", monoLabel, response.Category, response.Subcategory, absoluteAmount)
 	if transaction.IsRefund {
 		linkMsg += "\n🔄 Refund"
 	}


### PR DESCRIPTION
## What

Morph now forwards transactions from several banks, so a Telegram message with only Category / Subcategory / Amount no longer tells you which account it came from. The notification path already heads its messages with the app name (`📲 BBVA`, `📲 Privat24`) — this adds the same header to the two handlers that lacked one.

| Handler | Header |
| --- | --- |
| `MonoHandler` | `📲 Monobank` |
| `CashHandler` | `💵 Cash` |

```
📲 Monobank
Category: Food
Subcategory: Other
Amount: 25.53
🔄 Refund
https://morph-service.short.gy/3ce7CF
```

💵 rather than 📲 for cash, since it is not a phone push.

## Notes

- `CashHandler`'s message building switches from string concatenation to `fmt.Sprintf`, matching the other two handlers.
- Both happy-path tests now assert the full message text rather than substring checks, so the label and line order are pinned.
- `go build ./...`, `go vet ./...` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)