### PR TITLE
Update mcc dependency to 0.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/cloudtasks v1.19.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.9.2
 	github.com/invopop/jsonschema v0.14.0
-	github.com/maximbilan/mcc v0.0.0-20260809124657-e7db4802e55b
+	github.com/maximbilan/mcc v0.0.0-20260814171422-1a8fcb5184ff
 	github.com/openai/openai-go v1.12.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8i
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/maximbilan/mcc v0.0.0-20260809124657-e7db4802e55b h1:cZnReI4Ib1J4D0rzYdI+Jm6A6rINwLYorFWppP/k/I8=
-github.com/maximbilan/mcc v0.0.0-20260809124657-e7db4802e55b/go.mod h1:Lr5AI9PLaxugjJdtAUIPBtEF6lNjRiYB3B6NW4as7OU=
+github.com/maximbilan/mcc v0.0.0-20260814171422-1a8fcb5184ff h1:nT1E1hszeGSo+Maf6y2Km27fd659vZlxpK9Z8eaLLuw=
+github.com/maximbilan/mcc v0.0.0-20260814171422-1a8fcb5184ff/go.mod h1:Lr5AI9PLaxugjJdtAUIPBtEF6lNjRiYB3B6NW4as7OU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
Bumps `github.com/maximbilan/mcc` to [0.1.5](https://github.com/maximbilan/mcc/releases/tag/0.1.5), which adds MCC `3047` — Turkish Airlines.

Fixes the runtime error `MCC code not found: 3047`.

Note: the pseudo-version is expected — `mcc` tags releases without the `v` prefix, so Go can't resolve `0.1.5` as a semver tag and pins the commit instead. Same as the previous bump.

## Test plan
- `go build ./...` clean
- `go test ./...` all packages pass
- Verified end-to-end with a throwaway test: `category.GetCategoryFromMCC(3047)` returns `"Turkish Airlines"` (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)